### PR TITLE
fix: when location scheme is http

### DIFF
--- a/hx.js
+++ b/hx.js
@@ -1178,7 +1178,7 @@ var HXGlobalJS = function () {
     }
 
     // Match the site in case we need it for something later.
-    let courseSiteURL = windowURL.match(/https:\/\/.+\//)[0];
+    let courseSiteURL = windowURL.match(/https?:\/\/.+\//)[0];
 
     if (option == 'site') {
       return courseSiteURL;


### PR DESCRIPTION
  This chang simply makes the 's' optionl for regex
  pattern when extrcating course url.

  
